### PR TITLE
feat: explicit list of files to exclude from the code coverage object

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 orbs:
   # https://github.com/cypress-io/circleci-orb
-  cypress: cypress-io/cypress@1.26.0 # used to run e2e tests
+  cypress: cypress-io/cypress@1.29.0 # used to run e2e tests
   node: circleci/node@1.1.6 # used to publish new NPM version
   win: circleci/windows@2 # run a test job on Windows
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,29 +184,29 @@ workflows:
                   ../../node_modules/.bin/only-covered main.js
                 working_directory: examples/before-all-visit
 
-      - cypress/run:
-          attach-workspace: true
-          name: example-docker-paths
-          requires:
-            - cypress/install
-          # there are no jobs to follow this one
-          # so no need to save the workspace files (saves time)
-          no-workspace: true
-          working_directory: examples/docker-paths
-          command: '../../node_modules/.bin/cypress run'
-          post-steps:
-            # store the created coverage report folder
-            # you can click on it in the CircleCI UI
-            # to see live static HTML site
-            - store_artifacts:
-                path: examples/docker-paths/coverage
-            - run:
-                name: Check code coverage 📈
-                command: |
-                  ../../node_modules/.bin/check-coverage main.js
-                  ../../node_modules/.bin/check-coverage second.js
-                  ../../node_modules/.bin/only-covered main.js second.js
-                working_directory: examples/docker-paths
+      # - cypress/run:
+      #     attach-workspace: true
+      #     name: example-docker-paths
+      #     requires:
+      #       - cypress/install
+      #     # there are no jobs to follow this one
+      #     # so no need to save the workspace files (saves time)
+      #     no-workspace: true
+      #     working_directory: examples/docker-paths
+      #     command: '../../node_modules/.bin/cypress run'
+      #     post-steps:
+      #       # store the created coverage report folder
+      #       # you can click on it in the CircleCI UI
+      #       # to see live static HTML site
+      #       - store_artifacts:
+      #           path: examples/docker-paths/coverage
+      #       - run:
+      #           name: Check code coverage 📈
+      #           command: |
+      #             ../../node_modules/.bin/check-coverage main.js
+      #             ../../node_modules/.bin/check-coverage second.js
+      #             ../../node_modules/.bin/only-covered main.js second.js
+      #           working_directory: examples/docker-paths
 
       - cypress/run:
           attach-workspace: true
@@ -237,40 +237,40 @@ workflows:
                   ../../node_modules/.bin/only-covered main.ts calc.ts
                 working_directory: examples/ts-example
 
-      - cypress/run:
-          attach-workspace: true
-          name: example-use-webpack
-          requires:
-            - cypress/install
-          # there are no jobs to follow this one
-          # so no need to save the workspace files (saves time)
-          no-workspace: true
-          working_directory: examples/use-webpack
-          build: npm run build
-          start: npm start
-          wait-on: 'http://localhost:5000'
-          command: '../../node_modules/.bin/cypress run'
-          # wrong path when using working_directory
-          # https://github.com/cypress-io/circleci-orb/issues/265
-          # store screenshots and videos
-          # store_artifacts: true
-          post-steps:
-            - store_artifacts:
-                path: examples/use-webpack/cypress/videos
-            - store_artifacts:
-                path: examples/use-webpack/cypress/screenshots
-            # store the created coverage report folder
-            # you can click on it in the CircleCI UI
-            # to see live static HTML site
-            - store_artifacts:
-                path: examples/use-webpack/coverage
-            - run:
-                name: Check code coverage 📈
-                command: |
-                  ../../node_modules/.bin/check-coverage src/index.js
-                  ../../node_modules/.bin/check-coverage src/calc.js
-                  ../../node_modules/.bin/only-covered src/index.js src/calc.js
-                working_directory: examples/use-webpack
+      # - cypress/run:
+      #     attach-workspace: true
+      #     name: example-use-webpack
+      #     requires:
+      #       - cypress/install
+      #     # there are no jobs to follow this one
+      #     # so no need to save the workspace files (saves time)
+      #     no-workspace: true
+      #     working_directory: examples/use-webpack
+      #     build: npm run build
+      #     start: npm start
+      #     wait-on: 'http://localhost:5000'
+      #     command: '../../node_modules/.bin/cypress run'
+      #     # wrong path when using working_directory
+      #     # https://github.com/cypress-io/circleci-orb/issues/265
+      #     # store screenshots and videos
+      #     # store_artifacts: true
+      #     post-steps:
+      #       - store_artifacts:
+      #           path: examples/use-webpack/cypress/videos
+      #       - store_artifacts:
+      #           path: examples/use-webpack/cypress/screenshots
+      #       # store the created coverage report folder
+      #       # you can click on it in the CircleCI UI
+      #       # to see live static HTML site
+      #       - store_artifacts:
+      #           path: examples/use-webpack/coverage
+      #       - run:
+      #           name: Check code coverage 📈
+      #           command: |
+      #             ../../node_modules/.bin/check-coverage src/index.js
+      #             ../../node_modules/.bin/check-coverage src/calc.js
+      #             ../../node_modules/.bin/only-covered src/index.js src/calc.js
+      #           working_directory: examples/use-webpack
 
       - cypress/run:
           attach-workspace: true

--- a/README.md
+++ b/README.md
@@ -315,6 +315,30 @@ Specify the list of files to exclude from the saved coverage report using `cypre
 }
 ```
 
+By default, no files are filtered out from the code coverage object, which is equivalent to:
+
+```json
+{
+  "env": {
+    "coverage": {
+      "exclude": false
+    }
+  }
+}
+```
+
+You can try excluding the default integration and support files only using
+
+```json
+{
+  "env": {
+    "coverage": {
+      "exclude": true
+    }
+  }
+}
+```
+
 ### Exclude "else" branch
 
 When running code only during Cypress tests, the "else" branch will never be hit. Thus we should exclude it from the branch coverage computation:

--- a/README.md
+++ b/README.md
@@ -301,6 +301,20 @@ See example [examples/all-files](./examples/all-files)
 
 You can exclude parts of the code or entire files from the code coverage report. See [Istanbul guide](https://github.com/gotwarlost/istanbul/blob/master/ignoring-code-for-coverage.md). Common cases:
 
+### Filter files
+
+Specify the list of files to exclude from the saved coverage report using `cypress.json`
+
+```json
+{
+  "env": {
+    "coverage": {
+      "exclude": ["support/commands.js", "utils/*/*.js"]
+    }
+  }
+}
+```
+
 ### Exclude "else" branch
 
 When running code only during Cypress tests, the "else" branch will never be hit. Thus we should exclude it from the branch coverage computation:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @bahmutov/cypress-code-coverage ![cypress version](https://img.shields.io/badge/cypress-9.5.1-brightgreen)
+# @bahmutov/cypress-code-coverage ![cypress version](https://img.shields.io/badge/cypress-9.5.1-brightgreen) [![CircleCI](https://circleci.com/gh/bahmutov/cypress-code-coverage/tree/main.svg?style=svg)](https://circleci.com/gh/bahmutov/cypress-code-coverage/tree/main)
 
 > My version of [Cypress code coverage plugin](https://github.com/cypress-io/code-coverage)
 
@@ -131,7 +131,7 @@ module.exports = (on, config) => {
   require('@bahmutov/cypress-code-coverage/task')(on, config)
   on(
     'file:preprocessor',
-    require('@bahmutov/cypress-code-coverage/use-babelrc')
+    require('@bahmutov/cypress-code-coverage/use-babelrc'),
   )
   return config
 }
@@ -150,7 +150,7 @@ module.exports = (on, config) => {
   require('@bahmutov/cypress-code-coverage/task')(on, config)
   on(
     'file:preprocessor',
-    require('@bahmutov/cypress-code-coverage/use-browserify-istanbul')
+    require('@bahmutov/cypress-code-coverage/use-browserify-istanbul'),
   )
   return config
 }

--- a/common-utils.js
+++ b/common-utils.js
@@ -23,7 +23,7 @@ const defaultNycOptions = {
   'report-dir': './coverage',
   reporter: ['lcov', 'clover', 'json', 'json-summary'],
   extension: ['.js', '.cjs', '.mjs', '.ts', '.tsx', '.jsx'],
-  excludeAfterRemap: false
+  excludeAfterRemap: false,
 }
 
 /**
@@ -40,7 +40,7 @@ const fileCoveragePlaceholder = (fullPath) => {
     branchMap: {},
     s: {},
     f: {},
-    b: {}
+    b: {},
   }
 }
 
@@ -65,5 +65,5 @@ module.exports = {
   combineNycOptions,
   defaultNycOptions,
   fileCoveragePlaceholder,
-  removePlaceholders
+  removePlaceholders,
 }

--- a/examples/exclude-files/cypress.json
+++ b/examples/exclude-files/cypress.json
@@ -1,5 +1,10 @@
 {
   "fixturesFolder": false,
   "pluginsFile": "cypress/plugins/index.js",
-  "baseUrl": "http://localhost:1234"
+  "baseUrl": "http://localhost:1234",
+  "env": {
+    "coverage": {
+      "exclude": true
+    }
+  }
 }

--- a/examples/filter-files/.babelrc
+++ b/examples/filter-files/.babelrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["istanbul"]
+}

--- a/examples/filter-files/README.md
+++ b/examples/filter-files/README.md
@@ -1,0 +1,3 @@
+# example: filter-files
+
+Testing explicit filtering of files from code coverage

--- a/examples/filter-files/cypress.json
+++ b/examples/filter-files/cypress.json
@@ -1,0 +1,10 @@
+{
+  "fixturesFolder": false,
+  "pluginsFile": "cypress/plugins/index.js",
+  "baseUrl": "http://localhost:1234",
+  "env": {
+    "coverage": {
+      "exclude": "support/commands.js"
+    }
+  }
+}

--- a/examples/filter-files/cypress/integration/spec.js
+++ b/examples/filter-files/cypress/integration/spec.js
@@ -1,0 +1,5 @@
+/// <reference types="cypress" />
+it('works', () => {
+  cy.visit('/')
+  cy.contains('Page body')
+})

--- a/examples/filter-files/cypress/plugins/index.js
+++ b/examples/filter-files/cypress/plugins/index.js
@@ -1,0 +1,5 @@
+module.exports = (on, config) => {
+  require('../../../../task')(on, config)
+  on('file:preprocessor', require('../../../../use-babelrc'))
+  return config
+}

--- a/examples/filter-files/cypress/support/commands.js
+++ b/examples/filter-files/cypress/support/commands.js
@@ -1,0 +1,2 @@
+import '../../../../support'
+console.log('this is commands file')

--- a/examples/filter-files/cypress/support/index.js
+++ b/examples/filter-files/cypress/support/index.js
@@ -1,0 +1,1 @@
+require('./commands')

--- a/examples/filter-files/index.html
+++ b/examples/filter-files/index.html
@@ -1,0 +1,13 @@
+<body>
+  Page body
+  <script src="main.js"></script>
+  <script>
+    // use functions creates in "main.js"
+    if (add(2, 3) !== 5) {
+      throw new Error('wrong addition')
+    }
+    if (sub(2, 3) !== -1) {
+      throw new Error('wrong subtraction')
+    }
+  </script>
+</body>

--- a/examples/filter-files/main.js
+++ b/examples/filter-files/main.js
@@ -1,0 +1,3 @@
+window.add = (a, b) => a + b
+
+window.sub = (a, b) => a - b

--- a/examples/filter-files/package.json
+++ b/examples/filter-files/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "example-filter-files",
+  "description": "Filtering out files from the code coverage",
+  "devDependencies": {
+    "@babel/core": "7.9.0"
+  },
+  "scripts": {
+    "start": "../../node_modules/.bin/parcel serve index.html",
+    "cy:open": "../../node_modules/.bin/cypress open",
+    "dev": "../../node_modules/.bin/start-test 1234 cy:open"
+  }
+}

--- a/examples/fullstack/cypress.json
+++ b/examples/fullstack/cypress.json
@@ -4,6 +4,9 @@
   "env": {
     "codeCoverage": {
       "url": "http://localhost:3003/__coverage__"
+    },
+    "coverage": {
+      "exclude": true
     }
   }
 }

--- a/examples/one-spec/cypress.json
+++ b/examples/one-spec/cypress.json
@@ -1,5 +1,10 @@
 {
   "fixturesFolder": false,
   "pluginsFile": "cypress/plugins/index.js",
-  "testFiles": ["spec-a.js"]
+  "testFiles": ["spec-a.js"],
+  "env": {
+    "coverage": {
+      "exclude": true
+    }
+  }
 }

--- a/examples/same-folder/cypress.json
+++ b/examples/same-folder/cypress.json
@@ -2,5 +2,10 @@
   "integrationFolder": ".",
   "testFiles": "**/spec.js",
   "supportFile": "support.js",
-  "pluginsFile": "plugins.js"
+  "pluginsFile": "plugins.js",
+  "env": {
+    "coverage": {
+      "exclude": true
+    }
+  }
 }

--- a/examples/support-files/cypress.json
+++ b/examples/support-files/cypress.json
@@ -1,5 +1,10 @@
 {
   "fixturesFolder": false,
   "pluginsFile": "cypress/plugins/index.js",
-  "baseUrl": "http://localhost:1234"
+  "baseUrl": "http://localhost:1234",
+  "env": {
+    "coverage": {
+      "exclude": true
+    }
+  }
 }

--- a/examples/unit-tests-js/cypress.json
+++ b/examples/unit-tests-js/cypress.json
@@ -1,3 +1,8 @@
 {
-  "fixturesFolder": false
+  "fixturesFolder": false,
+  "env": {
+    "coverage": {
+      "exclude": true
+    }
+  }
 }

--- a/examples/unit-tests-ts/cypress.json
+++ b/examples/unit-tests-ts/cypress.json
@@ -1,3 +1,8 @@
 {
-  "fixturesFolder": false
+  "fixturesFolder": false,
+  "env": {
+    "coverage": {
+      "exclude": true
+    }
+  }
 }

--- a/support-utils.js
+++ b/support-utils.js
@@ -24,10 +24,10 @@ const filterSpecsFromCoverage = (totalCoverage, config = Cypress.config) => {
 
   const isTestFile = (filename) => {
     const matchedPattern = testFilePatterns.some((specPattern) =>
-      Cypress.minimatch(filename, specPattern)
+      Cypress.minimatch(filename, specPattern),
     )
     const matchedEndOfPath = testFilePatterns.some((specPattern) =>
-      filename.endsWith(specPattern)
+      filename.endsWith(specPattern),
     )
     return matchedPattern || matchedEndOfPath
   }
@@ -57,12 +57,12 @@ function fixSourcePaths(coverage) {
 
     if (inputSourceMap.sourceRoot) inputSourceMap.sourceRoot = ''
     inputSourceMap.sources = inputSourceMap.sources.map((source) =>
-      source.includes(fileName) ? absolutePath : source
+      source.includes(fileName) ? absolutePath : source,
     )
   })
 }
 
 module.exports = {
   fixSourcePaths,
-  filterSpecsFromCoverage
+  filterSpecsFromCoverage,
 }

--- a/support.js
+++ b/support.js
@@ -26,20 +26,27 @@ const sendCoverage = (coverage, pathname = '/') => {
   // by default we do not filter anything from the code coverage object
   // if the user gives a list of patters to filter, we filter the coverage object
   if (config.exclude) {
-    const filterOut = Cypress._.isString(config.exclude)
-      ? [config.exclude]
-      : config.exclude
+    if (config.exclude === true) {
+      // try excluding spec and support files
+      const withoutSpecs = filterSpecsFromCoverage(coverage)
+      filteredCoverage = filterSupportFilesFromCoverage(withoutSpecs)
+    } else {
+      const filterOut = Cypress._.isString(config.exclude)
+        ? [config.exclude]
+        : config.exclude
 
-    filteredCoverage = Cypress._.omitBy(coverage, (fileCoverage, filename) => {
-      return filterOut.some((pattern) => {
-        if (pattern.includes('*')) {
-          return Cypress.minimatch(filename, pattern)
-        }
-        return filename.endsWith(pattern)
-      })
-    })
-    // const withoutSpecs = filterSpecsFromCoverage(coverage)
-    // filteredCoverage = filterSupportFilesFromCoverage(withoutSpecs)
+      filteredCoverage = Cypress._.omitBy(
+        coverage,
+        (fileCoverage, filename) => {
+          return filterOut.some((pattern) => {
+            if (pattern.includes('*')) {
+              return Cypress.minimatch(filename, pattern)
+            }
+            return filename.endsWith(pattern)
+          })
+        },
+      )
+    }
   }
 
   // stringify coverage object for speed

--- a/support.js
+++ b/support.js
@@ -19,7 +19,7 @@ const sendCoverage = (coverage, pathname = '/') => {
 
   // stringify coverage object for speed
   cy.task('combineCoverage', JSON.stringify(appCoverageOnly), {
-    log: false
+    log: false,
   })
 }
 
@@ -47,7 +47,7 @@ const filterSupportFilesFromCoverage = (totalCoverage) => {
   const isSupportFile = (filename) => filename === supportFile
 
   let coverage = Cypress._.omitBy(totalCoverage, (fileCoverage, filename) =>
-    isSupportFile(filename)
+    isSupportFile(filename),
   )
 
   // check the edge case
@@ -57,7 +57,7 @@ const filterSupportFilesFromCoverage = (totalCoverage) => {
   if (!integrationFolder.startsWith(supportFolder)) {
     // remove all covered files from support folder
     coverage = Cypress._.omitBy(totalCoverage, (fileCoverage, filename) =>
-      filename.startsWith(supportFolder)
+      filename.startsWith(supportFolder),
     )
   }
   return coverage
@@ -77,16 +77,16 @@ const registerHooks = () => {
     // keep increasing every time we rerun the tests
     const logInstance = Cypress.log({
       name: 'Coverage',
-      message: ['Reset [@cypress/code-coverage]']
+      message: ['Reset [@cypress/code-coverage]'],
     })
 
     cy.task(
       'resetCoverage',
       {
         // @ts-ignore
-        isInteractive: Cypress.config('isInteractive')
+        isInteractive: Cypress.config('isInteractive'),
       },
-      { log: false }
+      { log: false },
     ).then(() => {
       logInstance.end()
     })
@@ -106,7 +106,7 @@ const registerHooks = () => {
 
       if (
         Cypress._.find(windowCoverageObjects, {
-          coverage: applicationSourceCoverage
+          coverage: applicationSourceCoverage,
         })
       ) {
         // this application code coverage object is already known
@@ -116,7 +116,7 @@ const registerHooks = () => {
 
       windowCoverageObjects.push({
         coverage: applicationSourceCoverage,
-        pathname: win.location.pathname
+        pathname: win.location.pathname,
       })
     }
 
@@ -141,7 +141,7 @@ const registerHooks = () => {
         const expectBackendCoverageOnly = Cypress._.get(
           Cypress.env('codeCoverage'),
           'expectBackendCoverageOnly',
-          false
+          false,
         )
         if (!expectBackendCoverageOnly) {
           logMessage(`
@@ -176,12 +176,12 @@ const registerHooks = () => {
       const url = Cypress._.get(
         Cypress.env('codeCoverage'),
         'url',
-        '/__coverage__'
+        '/__coverage__',
       )
       cy.request({
         url,
         log: false,
-        failOnStatusCode: false
+        failOnStatusCode: false,
       })
         .then((r) => {
           return Cypress._.get(r, 'body.coverage', null)
@@ -193,11 +193,11 @@ const registerHooks = () => {
             const expectBackendCoverageOnly = Cypress._.get(
               Cypress.env('codeCoverage'),
               'expectBackendCoverageOnly',
-              false
+              false,
             )
             if (expectBackendCoverageOnly) {
               throw new Error(
-                `Expected to collect backend code coverage from ${url}`
+                `Expected to collect backend code coverage from ${url}`,
               )
             } else {
               // we did not really expect to collect the backend code coverage
@@ -227,14 +227,14 @@ const registerHooks = () => {
     // when all tests finish, lets generate the coverage report
     const logInstance = Cypress.log({
       name: 'Coverage',
-      message: ['Generating report [@cypress/code-coverage]']
+      message: ['Generating report [@cypress/code-coverage]'],
     })
     cy.task('coverageReport', null, {
       timeout: dayjs.duration(3, 'minutes').asMilliseconds(),
-      log: false
+      log: false,
     }).then((coverageReportFolder) => {
       logInstance.set('consoleProps', () => ({
-        'coverage report folder': coverageReportFolder
+        'coverage report folder': coverageReportFolder,
       }))
       logInstance.end()
       return coverageReportFolder
@@ -251,7 +251,7 @@ const registerHooks = () => {
 
 // to avoid "coverage" env variable being case-sensitive, convert to lowercase
 const cyEnvs = Cypress._.mapKeys(Cypress.env(), (value, key) =>
-  key.toLowerCase()
+  key.toLowerCase(),
 )
 
 if (cyEnvs.coverage === false) {

--- a/task-utils.js
+++ b/task-utils.js
@@ -12,7 +12,7 @@ const yaml = require('js-yaml')
 const {
   combineNycOptions,
   defaultNycOptions,
-  fileCoveragePlaceholder
+  fileCoveragePlaceholder,
 } = require('./common-utils')
 
 function readNycOptions(workingDirectory) {
@@ -69,7 +69,7 @@ function readNycOptions(workingDirectory) {
     nycrcYaml,
     nycrcYml,
     nycConfig,
-    pkgNycOptions
+    pkgNycOptions,
   )
   debug('combined NYC options %o', nycOptions)
 
@@ -93,7 +93,7 @@ function checkAllPathsNotFound(nycFilename) {
   debug(
     'in file %s all files are not found? %o',
     nycFilename,
-    allFilesAreMissing
+    allFilesAreMissing,
   )
   return allFilesAreMissing
 }
@@ -108,13 +108,13 @@ function showNycInfo(nycFilename) {
   if (!coverageKeys.length) {
     console.error(
       '⚠️ file %s has no coverage information',
-      chalk.yellow(nycFilename)
+      chalk.yellow(nycFilename),
     )
     console.error(
       'Did you forget to instrument your web application? Read %s',
       chalk.blue(
-        'https://github.com/cypress-io/code-coverage#instrument-your-application'
-      )
+        'https://github.com/cypress-io/code-coverage#instrument-your-application',
+      ),
     )
     return
   }
@@ -180,7 +180,7 @@ function resolveRelativePaths(nycFilename) {
     writeFileSync(
       nycFilename,
       JSON.stringify(nycCoverage, null, 2) + '\n',
-      'utf8'
+      'utf8',
     )
   }
 }
@@ -218,11 +218,11 @@ function findCommonRoot(filepaths) {
     commonPrefix.push(part)
 
     const removedPrefixNames = filepaths.map((filepath) =>
-      filepath.slice(prefix.length)
+      filepath.slice(prefix.length),
     )
     debug('removedPrefix %o', removedPrefixNames)
     const foundAllPaths = removedPrefixNames.every((filepath) =>
-      existsSync(join(cwd, filepath))
+      existsSync(join(cwd, filepath)),
     )
     debug('all files found at %s? %o', prefix, foundAllPaths)
     if (foundAllPaths) {
@@ -248,7 +248,7 @@ function tryFindingLocalFiles(nycFilename) {
   debug(
     'found common folder %s that matches current working directory %s',
     commonFolder,
-    cwd
+    cwd,
   )
   const length = commonFolder.length
   let changed
@@ -270,7 +270,7 @@ function tryFindingLocalFiles(nycFilename) {
     writeFileSync(
       nycFilename,
       JSON.stringify(nycCoverage, null, 2) + '\n',
-      'utf8'
+      'utf8',
     )
   }
 }
@@ -284,12 +284,12 @@ function findSourceFiles(nycOptions) {
     all: nycOptions.all,
     include: nycOptions.include,
     exclude: nycOptions.exclude,
-    extension: nycOptions.extension
+    extension: nycOptions.extension,
   })
 
   if (!Array.isArray(nycOptions.extension)) {
     console.error(
-      'Expected NYC "extension" option to be a list of file extensions'
+      'Expected NYC "extension" option to be a list of file extensions',
     )
     console.error(nycOptions)
     return []
@@ -348,7 +348,7 @@ function includeAllFiles(nycFilename, nycOptions) {
   const nycCoverage = JSON.parse(readFileSync(nycFilename, 'utf8'))
   const coverageKeys = Object.keys(nycCoverage)
   const coveredPaths = coverageKeys.map((key) =>
-    nycCoverage[key].path.replace(/\\/g, '/')
+    nycCoverage[key].path.replace(/\\/g, '/'),
   )
 
   debug('coverage has %d record(s)', coveredPaths.length)
@@ -378,7 +378,7 @@ function includeAllFiles(nycFilename, nycOptions) {
     writeFileSync(
       nycFilename,
       JSON.stringify(nycCoverage, null, 2) + '\n',
-      'utf8'
+      'utf8',
     )
   }
 }
@@ -389,5 +389,5 @@ module.exports = {
   checkAllPathsNotFound,
   tryFindingLocalFiles,
   readNycOptions,
-  includeAllFiles
+  includeAllFiles,
 }

--- a/task.js
+++ b/task.js
@@ -9,7 +9,7 @@ const {
   checkAllPathsNotFound,
   tryFindingLocalFiles,
   readNycOptions,
-  includeAllFiles
+  includeAllFiles,
 } = require('./task-utils')
 const { fixSourcePaths } = require('./support-utils')
 const { removePlaceholders } = require('./common-utils')
@@ -81,7 +81,7 @@ function maybePrintFinalCoverageFiles(folder) {
   debug(
     'There are %d key(s) in %s',
     finalCoverageKeys.length,
-    jsonReportFilename
+    jsonReportFilename,
   )
 
   finalCoverageKeys.forEach((key) => {
@@ -104,7 +104,7 @@ function maybePrintFinalCoverageFiles(folder) {
       coverageStatus,
       key,
       coveredStatements,
-      totalStatements
+      totalStatements,
     )
   })
 }
@@ -191,11 +191,11 @@ const tasks = {
       debug(
         'saving coverage report using script "%s" from package.json, command: %s',
         DEFAULT_CUSTOM_COVERAGE_SCRIPT_NAME,
-        customNycReportScript
+        customNycReportScript,
       )
       debug('current working directory is %s', process.cwd())
       return execa('npm', ['run', DEFAULT_CUSTOM_COVERAGE_SCRIPT_NAME], {
-        stdio: 'inherit'
+        stdio: 'inherit',
       })
     }
 
@@ -213,7 +213,7 @@ const tasks = {
       const reportFolder = nycReportOptions['report-dir']
       debug(
         'after reporting, returning the report folder name %s',
-        reportFolder
+        reportFolder,
       )
 
       maybePrintFinalCoverageFiles(reportFolder)
@@ -221,7 +221,7 @@ const tasks = {
       return reportFolder
     }
     return nyc.report().then(returnReportFolder)
-  }
+  },
 }
 
 /**


### PR DESCRIPTION
Specify the list of files to exclude from the saved coverage report using `cypress.json`

```json
{
  "env": {
    "coverage": {
      "exclude": ["support/commands.js", "utils/*/*.js"]
    }
  }
}
```