### PR TITLE
fix: do not try to generate NYC report if there is no NYC output JSON file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -264,6 +264,19 @@ workflows:
                   ../../node_modules/.bin/only-covered first.js second.js third.js
                 working_directory: examples/multiple-files
 
+      - cypress/run:
+          attach-workspace: true
+          name: example-no-files
+          requires:
+            - cypress/install
+          # there are no jobs to follow this one
+          # so no need to save the workspace files (saves time)
+          no-workspace: true
+          working_directory: examples/no-files
+          start: npm start
+          wait-on: 'http://localhost:1234'
+          command: '../../node_modules/.bin/cypress run'
+
       # - cypress/run:
       #     attach-workspace: true
       #     name: example-use-webpack

--- a/examples/no-files/.babelrc
+++ b/examples/no-files/.babelrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["istanbul"]
+}

--- a/examples/no-files/README.md
+++ b/examples/no-files/README.md
@@ -1,0 +1,3 @@
+# example: no-files
+
+All tests are skipped, no code coverage

--- a/examples/no-files/cypress.json
+++ b/examples/no-files/cypress.json
@@ -1,0 +1,11 @@
+{
+  "fixturesFolder": false,
+  "pluginsFile": "cypress/plugins/index.js",
+  "baseUrl": "http://localhost:1234",
+  "video": false,
+  "env": {
+    "coverage": {
+      "exclude": true
+    }
+  }
+}

--- a/examples/no-files/cypress/integration/spec.js
+++ b/examples/no-files/cypress/integration/spec.js
@@ -1,0 +1,5 @@
+/// <reference types="cypress" />
+it.skip('works', () => {
+  cy.visit('/')
+  cy.contains('Page body')
+})

--- a/examples/no-files/cypress/plugins/index.js
+++ b/examples/no-files/cypress/plugins/index.js
@@ -1,0 +1,6 @@
+module.exports = (on, config) => {
+  require('../../../../plugin')(on, config)
+  // do not instrument the spec files
+  // on('file:preprocessor', require('../../../../use-babelrc'))
+  return config
+}

--- a/examples/no-files/cypress/support/commands.js
+++ b/examples/no-files/cypress/support/commands.js
@@ -1,0 +1,2 @@
+import '../../../../support'
+console.log('this is commands file')

--- a/examples/no-files/cypress/support/index.js
+++ b/examples/no-files/cypress/support/index.js
@@ -1,0 +1,1 @@
+require('./commands')

--- a/examples/no-files/index.html
+++ b/examples/no-files/index.html
@@ -1,0 +1,13 @@
+<body>
+  Page body
+  <script src="main.js"></script>
+  <script>
+    // use functions creates in "main.js"
+    if (add(2, 3) !== 5) {
+      throw new Error('wrong addition')
+    }
+    if (sub(2, 3) !== -1) {
+      throw new Error('wrong subtraction')
+    }
+  </script>
+</body>

--- a/examples/no-files/main.js
+++ b/examples/no-files/main.js
@@ -1,0 +1,3 @@
+window.add = (a, b) => a + b
+
+window.sub = (a, b) => a - b

--- a/examples/no-files/package.json
+++ b/examples/no-files/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "example-filter-files",
+  "description": "Filtering out files from the code coverage",
+  "devDependencies": {
+    "@babel/core": "7.9.0"
+  },
+  "scripts": {
+    "start": "../../node_modules/.bin/parcel serve index.html",
+    "cy:open": "../../node_modules/.bin/cypress open",
+    "cy:run": "../../node_modules/.bin/cypress run",
+    "dev": "../../node_modules/.bin/start-test 1234 cy:open",
+    "clean": "rm -rf .nyc_output coverage",
+    "e2e": "../../node_modules/.bin/start-test 1234 cy:run",
+    "pree2e": "npm run clean"
+  }
+}

--- a/plugin.js
+++ b/plugin.js
@@ -1,8 +1,13 @@
+const { getNycReportFilename } = require('./task-utils')
+const { existsSync } = require('fs')
 const NYC = require('nyc')
+
 const nyc = new NYC({
   cwd: process.cwd(),
   reporter: 'text',
 })
+
+const nycFilename = getNycReportFilename(process.cwd())
 
 function registerCodeCoveragePlugin(on, config) {
   require('./task')(on, config)
@@ -18,8 +23,12 @@ function registerCodeCoveragePlugin(on, config) {
 
   if (reportAfterEachSpec) {
     on('after:spec', (t) => {
-      console.log('after spec %s', t.relative)
-      return nyc.report()
+      console.log('code coverage after spec %s', t.relative)
+      if (existsSync(nycFilename)) {
+        return nyc.report()
+      } else {
+        console.warn('Could not find coverage file %s', nycFilename)
+      }
     })
   }
 

--- a/support-utils.js
+++ b/support-utils.js
@@ -1,3 +1,4 @@
+/// <reference types="cypress" />
 // @ts-check
 // helper functions that are safe to use in the browser
 // from support.js file - no file system access

--- a/task-utils.js
+++ b/task-utils.js
@@ -106,6 +106,13 @@ function getNycOptions(workingDirectory) {
   return nycReportOptions
 }
 
+function getNycReportFilename(workingDirectory) {
+  const nycReportOptions = getNycOptions(workingDirectory)
+
+  const nycFilename = join(nycReportOptions['temp-dir'], 'out.json')
+  return nycFilename
+}
+
 function checkAllPathsNotFound(nycFilename) {
   const nycCoverage = JSON.parse(readFileSync(nycFilename, 'utf8'))
 
@@ -442,5 +449,6 @@ module.exports = {
   tryFindingLocalFiles,
   readNycOptions,
   getNycOptions,
+  getNycReportFilename,
   includeAllFiles,
 }

--- a/task-utils.js
+++ b/task-utils.js
@@ -76,6 +76,36 @@ function readNycOptions(workingDirectory) {
   return nycOptions
 }
 
+function getNycOptions(workingDirectory) {
+  if (!workingDirectory) {
+    workingDirectory = process.cwd()
+  }
+
+  // https://github.com/istanbuljs/nyc#common-configuration-options
+  const nycReportOptions = readNycOptions(workingDirectory)
+
+  if (nycReportOptions.exclude && !Array.isArray(nycReportOptions.exclude)) {
+    console.error('NYC options: %o', nycReportOptions)
+    throw new Error('Expected "exclude" to by an array')
+  }
+
+  if (nycReportOptions['temp-dir']) {
+    nycReportOptions['temp-dir'] = resolve(nycReportOptions['temp-dir'])
+  } else {
+    nycReportOptions['temp-dir'] = join(workingDirectory, '.nyc_output')
+  }
+
+  nycReportOptions.tempDir = nycReportOptions['temp-dir']
+
+  if (nycReportOptions['report-dir']) {
+    nycReportOptions['report-dir'] = resolve(nycReportOptions['report-dir'])
+  }
+  // seems nyc API really is using camel cased version
+  nycReportOptions.reportDir = nycReportOptions['report-dir']
+
+  return nycReportOptions
+}
+
 function checkAllPathsNotFound(nycFilename) {
   const nycCoverage = JSON.parse(readFileSync(nycFilename, 'utf8'))
 
@@ -411,5 +441,6 @@ module.exports = {
   checkAllPathsNotFound,
   tryFindingLocalFiles,
   readNycOptions,
+  getNycOptions,
   includeAllFiles,
 }

--- a/task.js
+++ b/task.js
@@ -1,6 +1,6 @@
 // @ts-check
 const istanbul = require('istanbul-lib-coverage')
-const { join, resolve } = require('path')
+const { join } = require('path')
 const { existsSync, mkdirSync, readFileSync, writeFileSync } = require('fs')
 const execa = require('execa')
 const {
@@ -8,7 +8,7 @@ const {
   resolveRelativePaths,
   checkAllPathsNotFound,
   tryFindingLocalFiles,
-  readNycOptions,
+  getNycOptions,
   includeAllFiles,
 } = require('./task-utils')
 const { fixSourcePaths } = require('./support-utils')
@@ -31,31 +31,7 @@ const scripts = pkg.scripts || {}
 const DEFAULT_CUSTOM_COVERAGE_SCRIPT_NAME = 'coverage:report'
 const customNycReportScript = scripts[DEFAULT_CUSTOM_COVERAGE_SCRIPT_NAME]
 
-const nycReportOptions = (function getNycOption() {
-  // https://github.com/istanbuljs/nyc#common-configuration-options
-  const nycReportOptions = readNycOptions(processWorkingDirectory)
-
-  if (nycReportOptions.exclude && !Array.isArray(nycReportOptions.exclude)) {
-    console.error('NYC options: %o', nycReportOptions)
-    throw new Error('Expected "exclude" to by an array')
-  }
-
-  if (nycReportOptions['temp-dir']) {
-    nycReportOptions['temp-dir'] = resolve(nycReportOptions['temp-dir'])
-  } else {
-    nycReportOptions['temp-dir'] = join(processWorkingDirectory, '.nyc_output')
-  }
-
-  nycReportOptions.tempDir = nycReportOptions['temp-dir']
-
-  if (nycReportOptions['report-dir']) {
-    nycReportOptions['report-dir'] = resolve(nycReportOptions['report-dir'])
-  }
-  // seems nyc API really is using camel cased version
-  nycReportOptions.reportDir = nycReportOptions['report-dir']
-
-  return nycReportOptions
-})()
+const nycReportOptions = getNycOptions(processWorkingDirectory)
 
 const nycFilename = join(nycReportOptions['temp-dir'], 'out.json')
 


### PR DESCRIPTION
- closes #3 