### PR TITLE
fix: guard against cross-origin requests

### DIFF
--- a/examples/one-spec/cypress/integration/spec-a.js
+++ b/examples/one-spec/cypress/integration/spec-a.js
@@ -3,11 +3,12 @@ it('spec a', () => {
   cy.visit('index.html')
   cy.contains('Page body')
 
-  cy.window()
-    .invoke('add', 2, 3)
-    .should('equal', 5)
+  cy.window().invoke('add', 2, 3).should('equal', 5)
 
-  cy.window()
-    .invoke('sub', 2, 3)
-    .should('equal', -1)
+  cy.window().invoke('sub', 2, 3).should('equal', -1)
+})
+
+it.only('goes to another origin', () => {
+  cy.visit('index.html')
+  cy.get('a[title="another site"]').click()
 })

--- a/examples/one-spec/cypress/integration/spec-a.js
+++ b/examples/one-spec/cypress/integration/spec-a.js
@@ -8,7 +8,7 @@ it('spec a', () => {
   cy.window().invoke('sub', 2, 3).should('equal', -1)
 })
 
-it.only('goes to another origin', () => {
+it('goes to another origin', () => {
   cy.visit('index.html')
   cy.get('a[title="another site"]').click()
 })

--- a/examples/one-spec/index.html
+++ b/examples/one-spec/index.html
@@ -1,4 +1,6 @@
 <body>
-  Page body
+  <h1>One spec</h1>
+  <p>Page body</p>
+  <p><a href="https://cypress.tips" title="another site">cypress.tips</a></p>
   <script src="main-instrumented.js"></script>
 </body>

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "effective:config": "circleci config process .circleci/config.yml | sed /^#/d",
     "types": "tsc --noEmit --allowJs *.js cypress/e2e/*.js",
     "clean": "rm -rf .nyc_output coverage",
-    "stop-only": "stop-only --folder cypress/e2e"
+    "stop-only": "stop-only --folder cypress/e2e --folder examples --skip node_modules"
   },
   "peerDependencies": {
     "cypress": ">=10.0.0"


### PR DESCRIPTION
- ignore the window access errors when trying to grab the code coverage object
- closes #18 